### PR TITLE
Fix issue with setting hint button to active...

### DIFF
--- a/components/Game.qml
+++ b/components/Game.qml
@@ -82,12 +82,10 @@ Column {
             source: Qt.resolvedUrl("../hint2.svg")
             text: active ? persistentState.contents.hint : "No more today"
             property bool active: persistentState.contents.hint > 0
-            onActiveChanged: {
-                hint.enabled = active;
-            }
             MouseArea {
                 id: hint
                 anchors.fill: parent
+                enabled: parent.active
                 onPressed: grid.hinting = true;
                 onReleased: {
                     grid.hinting = false;


### PR DESCRIPTION
which caused hints to be accessible even when formally depleted if the user
navigated away from the puzzle grid (e.g. to home page) and then back again.

Turns out the side-effect on LabelButton.active change was not needed, it's just
that the MouseArea needed to reference the parent's active property, presumably
because it already had active defined in its own namespace.
